### PR TITLE
fix roulette and tournament selection

### DIFF
--- a/src/genetic/selection/RouletteWheel.ts
+++ b/src/genetic/selection/RouletteWheel.ts
@@ -15,7 +15,9 @@ export default class RouletteWheel implements Selection {
     }
     
     selectBest(evaluatedIndividuals: number[]): number[][] {
-        let individuals = this.changeIndiviudal(evaluatedIndividuals)
+        let bias = 1
+        let offset = Math.abs(Math.min(...evaluatedIndividuals)) + bias
+        let individuals = this.changeIndiviudal(evaluatedIndividuals, offset)
         let sum = individuals.reduce((sum, num)=>sum+num, 0)
         let probabilites = individuals.map(it=>it/sum)
         let distributors = this.calculateDistributors(probabilites)
@@ -34,12 +36,12 @@ export default class RouletteWheel implements Selection {
     }
 
 
-    private changeIndiviudal(evaluatedIndividuals: number[]): number[]{
+    private changeIndiviudal(evaluatedIndividuals: number[], offset: number): number[]{
         switch(this.extreme) {
             case ExtremeType.MIN:
-                return evaluatedIndividuals.map((it)=>1/it)
+                return evaluatedIndividuals.map((it)=>1/(it + offset))
             case ExtremeType.MAX:
-                return evaluatedIndividuals  
+                return evaluatedIndividuals.map(it=>it+offset)  
         }
     }
 

--- a/src/genetic/selection/TournamentSelection.ts
+++ b/src/genetic/selection/TournamentSelection.ts
@@ -18,13 +18,17 @@ export default class TournamentSelection implements Selection {
     setExtremeType(extremeType: ExtremeType) { this.extreme = extremeType } 
 
     selectBest(evaluatedIndividuals: number[]): Map<number, number> {
-        const n = evaluatedIndividuals.length/this.k
+        const n = Math.ceil(evaluatedIndividuals.length/this.k)
+        const reminder =  evaluatedIndividuals.length%this.k
         const randomIndexs = getRandomIndexs(evaluatedIndividuals.length)
         let bests = new Map()
         for(let i = 0; i<n; i++) {
-            let bestIndex = randomIndexs[i*n]
+            let bestIndex = randomIndexs[i*this.k]
             let best = evaluatedIndividuals[bestIndex]
             for(let j = 1; j<this.k; j++) {
+                if(i == n-1 && j >= reminder) {
+                    break;
+                }
                 let index = randomIndexs[i*n+j]
                 const next = evaluatedIndividuals[index]
                 switch(this.extreme) {

--- a/src/test/selection.test.ts
+++ b/src/test/selection.test.ts
@@ -4,27 +4,74 @@ import ExtremeType from "../enum/ExtremeType"
 import RouletteWheel from "../genetic/selection/RouletteWheel"
 import BestScoreSelection from "../genetic/selection/BestScoreSelection"
 
-test("Tournament selection test", () => {
+test("Tournament selection test odd indivduals number", () => {
     let selection: Selection = new TournamentSelection(3, ExtremeType.MAX)
     let evaluatedIndividuals: number[] = [23, 17.5, 13, 37, 11.125, 26.125, 149.5, 65.5, 195.125]
     let bests = selection.selectBest(evaluatedIndividuals)
-    
+    console.log(bests)
     expect(bests.has(8)).toBe(true)
 
     selection.setExtremeType(ExtremeType.MIN)
     bests = selection.selectBest(evaluatedIndividuals)
-
+    console.log(bests)
     expect(bests.has(4)).toBe(true)
 })
 
-test("Roulette wheel selection test", ()=> {
+test("Tournament selection test even individuals number", () => {
+    let selection: Selection = new TournamentSelection(3, ExtremeType.MAX)
+    let evaluatedIndividuals: number[] = [23, 17.5, 13, 37, 11.125, 26.125, 10, 149.5, 65.5, 195.125]
+    let bests = selection.selectBest(evaluatedIndividuals)
+    console.log(bests)
+    expect(bests.has(9)).toBe(true)
+
+    selection.setExtremeType(ExtremeType.MIN)
+    bests = selection.selectBest(evaluatedIndividuals)
+
+    expect(bests.has(6)).toBe(true)
+})
+
+
+//SOMETIMES this test might randomly faild, because those depends on probability, but in most cases they should pass
+test("Roulette wheel selection test MAX", ()=> {
     let selection: Selection = new RouletteWheel(ExtremeType.MAX) 
     let evaluatedIndividuals: number[] = [23, 17.5, 13, 37, 11.125, 26.125, 149.5, 65.5, 195.125]
     let bests = selection.selectBest(evaluatedIndividuals)
     expect(bests[0].includes(195.125)).toBe(true)
-    selection.setExtremeType(ExtremeType.MIN)
-    bests = selection.selectBest(evaluatedIndividuals)
+})
+
+test("Roulette wheel selection test MAX negative numbers", ()=> {
+    let selection: Selection = new RouletteWheel(ExtremeType.MAX) 
+    let evaluatedIndividuals: number[] = [-23, -17.5, -13, -37, -11.125, -26.125, -149.5, -65.5, 195.125]
+    let bests = selection.selectBest(evaluatedIndividuals)
+    expect(bests[0].includes(195.125)).toBe(true)
+})
+
+test("Roulette wheel selection test MAX all negative numbers", ()=> {
+    let selection: Selection = new RouletteWheel(ExtremeType.MAX) 
+    let evaluatedIndividuals: number[] = [-23, -17.5, -13, -37, -11.125, -26.125, -149.5, -65.5, -195.125]
+    let bests = selection.selectBest(evaluatedIndividuals)
+    expect(bests[0].includes(-11.125)).toBe(true)
+})
+
+test("Roulette wheel selection test MIN", ()=> {
+    let selection: Selection = new RouletteWheel(ExtremeType.MIN) 
+    let evaluatedIndividuals: number[] = [23, 17.5, 13, 37, 11.125, 26.125, 149.5, 65.5, 195.125]
+    let bests = selection.selectBest(evaluatedIndividuals)
     expect(bests[0].includes(11.125)).toBe(true)
+})
+
+test("Roulette wheel selection test MIN negative numbers", ()=> {
+    let selection: Selection = new RouletteWheel(ExtremeType.MIN) 
+    let evaluatedIndividuals: number[] = [23, 17.5, -13, 37, 11.125, 26.125, 149.5, 65.5, 195.125]
+    let bests = selection.selectBest(evaluatedIndividuals)
+    expect(bests[0].includes(-13)).toBe(true)
+})
+
+test("Roulette wheel selection test MIN all negative numbers", ()=> {
+    let selection: Selection = new RouletteWheel(ExtremeType.MIN) 
+    let evaluatedIndividuals: number[] = [-23, -17.5, -13, -37, -11.125, -26.125, -149.5, -65.5, -195.125]
+    let bests = selection.selectBest(evaluatedIndividuals)
+    expect(bests[0].includes(-195.125)).toBe(true)
 })
 
 test("Best score selection test MAX", ()=> {


### PR DESCRIPTION
Fixed:

- Roulette wheel now working with negative numbers.
- Tournament selection now works with array not divided by interval numbers.